### PR TITLE
Fix incorrect alias

### DIFF
--- a/src/DiscountRelations.php
+++ b/src/DiscountRelations.php
@@ -67,7 +67,7 @@ class DiscountRelations extends Plugin
 	public function init()
 	{
 
-		Craft::setAlias('@discount-relations', __DIR__);
+		Craft::setAlias('@topshelfcraft/discount-relations', __DIR__);
 		parent::init();
 
 		$this->_registerEventHandlers();


### PR DESCRIPTION
According to the Craft docs a module's alias should match the namespace. Fixes this error: `Exception 'yii\base\InvalidArgumentException' with message 'Invalid path alias: @topshelfcraft/discountrelations/controllers/console'`